### PR TITLE
Grasshopperファイル操作ツールの追加とRhino 8対応

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -84,7 +84,7 @@ https://github.com/user-attachments/assets/114e1331-c6fe-45f9-b28c-c88799c0643c
 
 ## システム要件
 
-- Rhino 9 WIP
+- Rhino 8 以降
 - .NET 8.0 Runtime
 
 ## 使用方法
@@ -454,6 +454,24 @@ Grasshopper関連の機能を提供するツール群です。
   - パラメータ：
     - `panel_id` (string, required) - パネルコンポーネントのGUID
     - `text` (string, required) - 設定するテキスト
+
+#### キャンバス・ファイル操作 (Canvas)
+
+- **load_grasshopper_file**
+  - 機能：GHX/GHファイルをGrasshopperに読み込み、ソリューションを実行
+  - パラメータ：
+    - `file_path` (string, required) - 読み込む.ghxまたは.ghファイルの絶対パス
+
+- **save_grasshopper_file**
+  - 機能：アクティブなGrasshopperドキュメントをGHX/GHファイルとして保存
+  - パラメータ：
+    - `file_path` (string, required) - 保存先の.ghxまたは.ghファイルの絶対パス
+    - `overwrite` (boolean, optional, default: false) - 既存ファイルを上書きするかどうか
+
+- **get_solution_status**
+  - 機能：アクティブなGrasshopperドキュメントのソリューション実行状態と全コンポーネントのランタイムメッセージを一括取得
+  - パラメータ：
+    - `include_messages` (boolean, optional, default: true) - 各コンポーネントの詳細メッセージを含めるかどうか
 
 ## ログ
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ https://github.com/user-attachments/assets/114e1331-c6fe-45f9-b28c-c88799c0643c
 
 ## System Requirements
 
-- Rhino 9 WIP
+- Rhino 8 or later
 - .NET 8.0 Runtime
 
 ## How to Use
@@ -461,6 +461,24 @@ Grasshopper integration tools.
   - Parameters:
     - `panel_id` (string, required) - GUID of the panel component
     - `text` (string, required) - Text to set
+
+#### Canvas / File Operations (Canvas)
+
+- **load_grasshopper_file**
+  - Function: Loads a GHX/GH file into Grasshopper as a new document and runs the solution
+  - Parameters:
+    - `file_path` (string, required) - Absolute path to the .ghx or .gh file to load
+
+- **save_grasshopper_file**
+  - Function: Saves the active Grasshopper document to a GHX/GH file
+  - Parameters:
+    - `file_path` (string, required) - Absolute path to save the file (.ghx or .gh)
+    - `overwrite` (boolean, optional, default: false) - Whether to overwrite an existing file
+
+- **get_solution_status**
+  - Function: Retrieves the solution status and all runtime messages from every component in the active Grasshopper document
+  - Parameters:
+    - `include_messages` (boolean, optional, default: true) - Whether to include detailed messages for each component
 
 ## Logs
 

--- a/Tools/RhinoMCPTools.Grasshopper/src/Canvas/GetSolutionStatusTool.cs
+++ b/Tools/RhinoMCPTools.Grasshopper/src/Canvas/GetSolutionStatusTool.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text.Json;
+using Grasshopper;
+using Grasshopper.Kernel;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using RhinoMCPServer.Common;
+
+namespace RhinoMCPTools.Grasshopper.Canvas
+{
+    /// <summary>
+    /// アクティブドキュメントのソリューション実行状態と、全コンポーネントのエラー・警告を一括取得する
+    /// </summary>
+    public class GetSolutionStatusTool : IMCPTool
+    {
+        public string Name => "get_solution_status";
+
+        public string Description => "Retrieves the solution status and all runtime messages from every component in the active Grasshopper document";
+
+        public JsonElement InputSchema => JsonSerializer.Deserialize<JsonElement>("""
+            {
+                "type": "object",
+                "properties": {
+                    "include_messages": {
+                        "type": "boolean",
+                        "description": "Whether to include detailed messages for each component",
+                        "default": true
+                    }
+                }
+            }
+            """);
+
+        public Task<CallToolResult> ExecuteAsync(CallToolRequestParams request, McpServer? server)
+        {
+            try
+            {
+                var doc = Instances.ActiveCanvas?.Document;
+                if (doc == null)
+                {
+                    throw new McpProtocolException("No active Grasshopper document found");
+                }
+
+                bool includeMessages = true;
+                if (request.Arguments != null &&
+                    request.Arguments.TryGetValue("include_messages", out var includeValue) &&
+                    includeValue is JsonElement includeElement)
+                {
+                    includeMessages = includeElement.GetBoolean();
+                }
+
+                int componentCount = 0;
+                int errorCount = 0;
+                int warningCount = 0;
+                int remarkCount = 0;
+                var componentsWithErrors = new List<object>();
+                var componentsWithWarnings = new List<object>();
+
+                foreach (var obj in doc.Objects)
+                {
+                    if (obj is not IGH_ActiveObject active)
+                    {
+                        continue;
+                    }
+
+                    componentCount++;
+
+                    var errors = active.RuntimeMessages(GH_RuntimeMessageLevel.Error);
+                    var warnings = active.RuntimeMessages(GH_RuntimeMessageLevel.Warning);
+                    var remarks = active.RuntimeMessages(GH_RuntimeMessageLevel.Remark);
+
+                    errorCount += errors.Count;
+                    warningCount += warnings.Count;
+                    remarkCount += remarks.Count;
+
+                    if (errors.Count > 0)
+                    {
+                        componentsWithErrors.Add(new
+                        {
+                            guid = obj.InstanceGuid.ToString(),
+                            name = obj.Name,
+                            nickname = obj.NickName,
+                            errors = includeMessages
+                                ? errors.Cast<string>().ToArray()
+                                : Array.Empty<string>(),
+                            warnings = includeMessages
+                                ? warnings.Cast<string>().ToArray()
+                                : Array.Empty<string>()
+                        });
+                    }
+                    else if (warnings.Count > 0)
+                    {
+                        componentsWithWarnings.Add(new
+                        {
+                            guid = obj.InstanceGuid.ToString(),
+                            name = obj.Name,
+                            nickname = obj.NickName,
+                            errors = Array.Empty<string>(),
+                            warnings = includeMessages
+                                ? warnings.Cast<string>().ToArray()
+                                : Array.Empty<string>()
+                        });
+                    }
+                }
+
+                var response = new
+                {
+                    status = "success",
+                    solution = new
+                    {
+                        component_count = componentCount,
+                        error_count = errorCount,
+                        warning_count = warningCount,
+                        remark_count = remarkCount,
+                        components_with_errors = componentsWithErrors.ToArray(),
+                        components_with_warnings = componentsWithWarnings.ToArray()
+                    }
+                };
+
+                return Task.FromResult(new CallToolResult()
+                {
+                    Content = [new TextContentBlock()
+                    {
+                        Text = JsonSerializer.Serialize(response, new JsonSerializerOptions
+                        {
+                            WriteIndented = true
+                        }),
+                    }]
+                });
+            }
+            catch (McpProtocolException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new McpProtocolException($"Error getting solution status: {ex.Message}", ex);
+            }
+        }
+    }
+}

--- a/Tools/RhinoMCPTools.Grasshopper/src/Canvas/LoadGrasshopperFileTool.cs
+++ b/Tools/RhinoMCPTools.Grasshopper/src/Canvas/LoadGrasshopperFileTool.cs
@@ -1,0 +1,159 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text.Json;
+using Grasshopper;
+using Grasshopper.Kernel;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Rhino;
+using RhinoMCPServer.Common;
+
+namespace RhinoMCPTools.Grasshopper.Canvas
+{
+    /// <summary>
+    /// GHX/GHファイルをGrasshopperに読み込み、新しいドキュメントとして開く
+    /// </summary>
+    public class LoadGrasshopperFileTool : IMCPTool
+    {
+        public string Name => "load_grasshopper_file";
+
+        public string Description => "Loads a GHX/GH file into Grasshopper as a new document and runs the solution";
+
+        public JsonElement InputSchema => JsonSerializer.Deserialize<JsonElement>("""
+            {
+                "type": "object",
+                "properties": {
+                    "file_path": {
+                        "type": "string",
+                        "description": "Absolute path to the .ghx or .gh file to load"
+                    }
+                },
+                "required": ["file_path"]
+            }
+            """);
+
+        public Task<CallToolResult> ExecuteAsync(CallToolRequestParams request, McpServer? server)
+        {
+            try
+            {
+                if (request.Arguments == null || !request.Arguments.TryGetValue("file_path", out var filePathValue))
+                {
+                    throw new McpProtocolException("file_path parameter is required");
+                }
+
+                var filePath = filePathValue.ToString()?.Trim('"');
+                if (string.IsNullOrEmpty(filePath))
+                {
+                    throw new McpProtocolException("file_path parameter must not be empty");
+                }
+
+                // 拡張子チェック
+                var ext = Path.GetExtension(filePath).ToLowerInvariant();
+                if (ext != ".ghx" && ext != ".gh")
+                {
+                    throw new McpProtocolException("Invalid file extension. Expected .ghx or .gh");
+                }
+
+                // ファイル存在確認
+                if (!File.Exists(filePath))
+                {
+                    throw new McpProtocolException($"File not found: {filePath}");
+                }
+
+                // UIスレッドでGH_DocumentIOを使用してファイルを読み込む
+                object? result = null;
+                RhinoApp.InvokeOnUiThread(new Action(() =>
+                {
+                    var io = new GH_DocumentIO();
+                    bool success = io.Open(filePath);
+
+                    if (!success || io.Document == null)
+                    {
+                        result = new { error = $"Failed to parse Grasshopper file: {filePath}" };
+                        return;
+                    }
+
+                    var doc = io.Document;
+
+                    // ドキュメントサーバーに登録
+                    var docServer = Instances.DocumentServer;
+                    docServer?.AddDocument(doc);
+
+                    // ソリューション実行
+                    doc.NewSolution(false);
+
+                    // アクティブドキュメントとして設定・キャンバス再描画
+                    doc.Enabled = true;
+                    Instances.RedrawCanvas();
+
+                    // IOメッセージの収集
+                    var ioMessages = new System.Collections.Generic.List<string>();
+
+                    // ドキュメント内のコンポーネントからパースエラーを収集
+                    bool hasErrors = false;
+                    bool hasWarnings = false;
+
+                    foreach (var obj in doc.Objects)
+                    {
+                        if (obj is IGH_ActiveObject active)
+                        {
+                            var errors = active.RuntimeMessages(GH_RuntimeMessageLevel.Error);
+                            var warnings = active.RuntimeMessages(GH_RuntimeMessageLevel.Warning);
+                            if (errors.Count > 0) hasErrors = true;
+                            if (warnings.Count > 0) hasWarnings = true;
+                        }
+                    }
+
+                    var componentCount = doc.Objects.Count(o => o is IGH_ActiveObject);
+
+                    result = new
+                    {
+                        status = "success",
+                        document = new
+                        {
+                            file_path = filePath,
+                            component_count = componentCount,
+                            has_errors = hasErrors,
+                            has_warnings = hasWarnings,
+                            io_messages = ioMessages.ToArray()
+                        }
+                    };
+                }));
+
+                // UIスレッドでエラーが発生した場合
+                if (result is { } r)
+                {
+                    var jsonStr = JsonSerializer.Serialize(r, new JsonSerializerOptions { WriteIndented = true });
+
+                    // エラーオブジェクトかチェック
+                    var jsonDoc = JsonSerializer.Deserialize<JsonElement>(jsonStr);
+                    if (jsonDoc.TryGetProperty("error", out var errorProp))
+                    {
+                        throw new McpProtocolException(errorProp.GetString() ?? "Unknown error");
+                    }
+
+                    return Task.FromResult(new CallToolResult()
+                    {
+                        Content = [new TextContentBlock()
+                        {
+                            Text = jsonStr,
+                        }]
+                    });
+                }
+
+                throw new McpProtocolException("Unexpected error: no result from UI thread operation");
+            }
+            catch (McpProtocolException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new McpProtocolException($"Error loading Grasshopper file: {ex.Message}", ex);
+            }
+        }
+    }
+}

--- a/Tools/RhinoMCPTools.Grasshopper/src/Canvas/SaveGrasshopperFileTool.cs
+++ b/Tools/RhinoMCPTools.Grasshopper/src/Canvas/SaveGrasshopperFileTool.cs
@@ -1,0 +1,152 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text.Json;
+using Grasshopper;
+using Grasshopper.Kernel;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Rhino;
+using RhinoMCPServer.Common;
+
+namespace RhinoMCPTools.Grasshopper.Canvas
+{
+    /// <summary>
+    /// アクティブなGrasshopperドキュメントをGHX/GHファイルとして保存する
+    /// </summary>
+    public class SaveGrasshopperFileTool : IMCPTool
+    {
+        public string Name => "save_grasshopper_file";
+
+        public string Description => "Saves the active Grasshopper document to a GHX/GH file";
+
+        public JsonElement InputSchema => JsonSerializer.Deserialize<JsonElement>("""
+            {
+                "type": "object",
+                "properties": {
+                    "file_path": {
+                        "type": "string",
+                        "description": "Absolute path to save the file (.ghx or .gh)"
+                    },
+                    "overwrite": {
+                        "type": "boolean",
+                        "description": "Whether to overwrite an existing file",
+                        "default": false
+                    }
+                },
+                "required": ["file_path"]
+            }
+            """);
+
+        public Task<CallToolResult> ExecuteAsync(CallToolRequestParams request, McpServer? server)
+        {
+            try
+            {
+                if (request.Arguments == null || !request.Arguments.TryGetValue("file_path", out var filePathValue))
+                {
+                    throw new McpProtocolException("file_path parameter is required");
+                }
+
+                var filePath = filePathValue.ToString()?.Trim('"');
+                if (string.IsNullOrEmpty(filePath))
+                {
+                    throw new McpProtocolException("file_path parameter must not be empty");
+                }
+
+                // 拡張子チェック
+                var ext = Path.GetExtension(filePath).ToLowerInvariant();
+                if (ext != ".ghx" && ext != ".gh")
+                {
+                    throw new McpProtocolException("Invalid file extension. Expected .ghx or .gh");
+                }
+
+                // overwriteパラメータ取得
+                bool overwrite = false;
+                if (request.Arguments.TryGetValue("overwrite", out var overwriteValue) &&
+                    overwriteValue is JsonElement overwriteElement)
+                {
+                    overwrite = overwriteElement.GetBoolean();
+                }
+
+                // ファイル既存チェック
+                if (!overwrite && File.Exists(filePath))
+                {
+                    throw new McpProtocolException($"File already exists: {filePath}. Set overwrite=true to replace");
+                }
+
+                // UIスレッドでGH_DocumentIOを使用して保存
+                object? result = null;
+                RhinoApp.InvokeOnUiThread(new Action(() =>
+                {
+                    var doc = Instances.ActiveCanvas?.Document;
+                    if (doc == null)
+                    {
+                        result = new { error = "No active Grasshopper document found" };
+                        return;
+                    }
+
+                    // 親ディレクトリが存在しない場合は作成
+                    var directory = Path.GetDirectoryName(filePath);
+                    if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                    {
+                        Directory.CreateDirectory(directory);
+                    }
+
+                    var io = new GH_DocumentIO(doc);
+                    bool success = io.SaveQuiet(filePath);
+
+                    if (!success)
+                    {
+                        result = new { error = $"Cannot write to path: {filePath}" };
+                        return;
+                    }
+
+                    var fileInfo = new FileInfo(filePath);
+                    var componentCount = doc.Objects.Count(o => o is IGH_ActiveObject);
+
+                    result = new
+                    {
+                        status = "success",
+                        file = new
+                        {
+                            path = filePath,
+                            size_bytes = fileInfo.Length,
+                            component_count = componentCount
+                        }
+                    };
+                }));
+
+                if (result is { } r)
+                {
+                    var jsonStr = JsonSerializer.Serialize(r, new JsonSerializerOptions { WriteIndented = true });
+
+                    var jsonDoc = JsonSerializer.Deserialize<JsonElement>(jsonStr);
+                    if (jsonDoc.TryGetProperty("error", out var errorProp))
+                    {
+                        throw new McpProtocolException(errorProp.GetString() ?? "Unknown error");
+                    }
+
+                    return Task.FromResult(new CallToolResult()
+                    {
+                        Content = [new TextContentBlock()
+                        {
+                            Text = jsonStr,
+                        }]
+                    });
+                }
+
+                throw new McpProtocolException("Unexpected error: no result from UI thread operation");
+            }
+            catch (McpProtocolException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new McpProtocolException($"Error saving Grasshopper file: {ex.Message}", ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Background
- GrasshopperのGHX/GHファイルをMCP経由で読み込み・保存する機能が必要だった
- ソリューション実行状態の一括取得により、デバッグワークフローを効率化したい
- Rhino 8での動作が可能になったため、システム要件を更新する必要があった

## Summary
- `load_grasshopper_file`: GHX/GHファイルの読み込みとソリューション実行ツールを追加
- `save_grasshopper_file`: アクティブドキュメントのGHX/GH保存ツールを追加
- `get_solution_status`: 全コンポーネントのランタイムメッセージ一括取得ツールを追加
- システム要件を Rhino 9 WIP から Rhino 8 以降に変更
- README (EN/JA) に新規Canvasツールのドキュメントを追加